### PR TITLE
Fixed furthest_sum initialization error

### DIFF
--- a/py_pcha/PCHA.py
+++ b/py_pcha/PCHA.py
@@ -150,7 +150,7 @@ def PCHA(X, noc, I=None, U=None, delta=0, verbose=False, conv_crit=1E-6, maxiter
 
     # Initialize C
     try:
-        i = furthest_sum(X[:, I], noc, [np.random.choice(I)])
+        i = furthest_sum(X[:, I], noc, [np.random.choice(np.array(I))])
     except IndexError:
         class InitializationException(Exception): pass
         raise InitializationException("Initialization does not converge. Too few examples in dataset.")

--- a/py_pcha/PCHA.py
+++ b/py_pcha/PCHA.py
@@ -150,7 +150,7 @@ def PCHA(X, noc, I=None, U=None, delta=0, verbose=False, conv_crit=1E-6, maxiter
 
     # Initialize C
     try:
-        i = furthest_sum(X[:, I], noc, [int(np.ceil(len(I) * np.random.rand()))])
+        i = furthest_sum(X[:, I], noc, [np.random.choice(I)])
     except IndexError:
         class InitializationException(Exception): pass
         raise InitializationException("Initialization does not converge. Too few examples in dataset.")


### PR DESCRIPTION
The furthest_sum procedure occasionally generates an initial index value that is exactly the length of `I`, which causes an `IndexError`. To fix it, I changed the index selection step to force it to select a valid value from `I`. 